### PR TITLE
Home page: conferentie 2019 - "save the date"

### DIFF
--- a/_includes/header-callout.html
+++ b/_includes/header-callout.html
@@ -5,5 +5,7 @@
 		<li>
 	     <a href="https://ieni.github.io/inf2019" target="_blank">SLO-keuzethema-materiaal</a>
     </li>
+		<li> i&i conferentie: 6 en 7 November 2019. Save the date!
+		</li>
 	</ul>
 </p>

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -8,7 +8,7 @@ headerCallout: true
 
 ## Samen werken we aan een slimmere samenleving
 Vakvereniging i&i maakt zich sterk voor een structureel aanbod van kwalitatief hoogwaardig onderwijs ten behoeve van informatica en digitale geletterdheid op alle basis- en middelbare scholen in Nederland.
-Zo ook met onze conferentie 2018 op 7 en 8 November. Voor meer informatie zie [i&i conferentie 2018](https://ieni.github.io/ieni2018/){:target="_blank"}.
+Zo ook met onze *conferentie 2019 op 6 ('s middags en 's avonds) en 7 November (hele dag)*. Daarover binnenkort meer!
 
 Iedereen die zich vanuit welke functie dan ook betrokken voelt bij informatica en digitale geletterdheid in het onderwijs verwelkomen wij als [lid](https://ieni.org/lid-worden). Dit zijn natuurlijk de docenten van dit onderwijs, maar ook leerlingen, ouders, schoolleiders en belangstellenden uit het bedrijfsleven.
 

--- a/_posts/2019-09-12-ieni-conferentie-2019.md
+++ b/_posts/2019-09-12-ieni-conferentie-2019.md
@@ -13,8 +13,7 @@ voor docenten informatica en digitale geletterdheid.
 
 Er zal veel aandacht zijn voor het nieuwe examenprogramma's,
 in het bijzonder voor het materiaal van de keuzethema's dat in samenwerking met SLO ontwikkeld wordt.
-
-Ook voor digitale geletterdheid is er weer de nodige aandacht..
+Ook digitale geletterdheid heeft onze aandacht..
 
 ## Locatie
 


### PR DESCRIPTION
And reference to previous conference removed.